### PR TITLE
Update smex after function calls that are likely to define new commands.

### DIFF
--- a/smex.el
+++ b/smex.el
@@ -488,5 +488,24 @@ sorted by frequency of use."
     (set-buffer-modified-p nil)
     (goto-char (point-min))))
 
+(defmacro update-smex-after (&rest functions)
+  "Advise each of FUNCTIONS to execute smex-update upon completion."
+  (cons
+   'progn
+   (mapcar (lambda (fun)
+             ;; Running this on `eval' causes an infinite loop, so
+             ;; don't do that.
+             (when (not (eq fun 'eval))
+               `(defadvice ,fun (after smex-update activate)
+                  "Run smex-update upon completion"
+                  (when (boundp 'smex-cache)
+                    (smex-update)))))
+           (mapcar 'eval
+                   functions))))
+
+;; If you just update smex after these functions, 
+;; you pretty much never need manual periodic updates.
+(update-smex-after 'load 'eval-last-sexp 'eval-buffer)
+
 (provide 'smex)
 ;;; smex.el ends here

--- a/smex.el
+++ b/smex.el
@@ -495,8 +495,9 @@ sorted by frequency of use."
    (mapcar (lambda (fun)
              `(defadvice ,fun (after smex-update activate)
                 "Run smex-update upon completion"
-                (when (bound-and-true-p 'smex-auto-update)
-                  (smex-update-if-needed))))
+                (ignore-errors
+                  (when (bound-and-true-p smex-auto-update)
+                    (smex-update-if-needed)))))
            ;; Defining advice on `eval' causes infinite recursion, so
            ;; don't allow that.
            (delete-if (apply-partially 'equal 'eval)

--- a/smex.el
+++ b/smex.el
@@ -505,7 +505,7 @@ sorted by frequency of use."
 
 ;; If you call `smex-update' after every invocation of just these few
 ;; functions, you almost never need any other updates.
-(smex-auto-update-after load eval-last-sexp eval-buffer eval-region)
+(smex-auto-update-after load eval-last-sexp eval-buffer eval-region eval-expression)
 
 (provide 'smex)
 ;;; smex.el ends here

--- a/smex.el
+++ b/smex.el
@@ -504,7 +504,7 @@ sorted by frequency of use."
 
 ;; If you call `smex-update' after every invocation of just these few
 ;; functions, you almost never need any other updates.
-(smex-auto-update-after load eval-last-sexp eval-buffer)
+(smex-auto-update-after load eval-last-sexp eval-buffer eval-region)
 
 (provide 'smex)
 ;;; smex.el ends here


### PR DESCRIPTION
I got tired of periodic smex auto updates, especially since every time I loaded a file or defined a new function, I would have to manually update smex anyway, since I immediately wanted access to the new functions that I just loaded. So I figured out which functions are involved in the definitions of _vast_ majority of commands, and I wrapped them in advice that updates smex immediately after them. Now when you load a file or press C-j in *scratch*, your new stuff is available with no waiting.
