### PR TITLE
Use customize to simplify startup

### DIFF
--- a/smex.el
+++ b/smex.el
@@ -109,7 +109,9 @@ to the location in `smex-save-file'."
                   smex-data nil))
           (smex-detect-new-commands)
           (smex-rebuild-cache)
-          (add-hook 'kill-emacs-hook 'smex-save-to-file)))))
+          (add-hook 'kill-emacs-hook 'smex-save-to-file))))
+  (smex-save-to-file)
+  (remove-hook 'kill-emacs-hook 'smex-save-to-file))
 
 (defun smex ()
   "Read a function name using ido-enhanced search and call it."


### PR DESCRIPTION
By using `define-minor-mode` with an `autoload` cookie, smex can be loaded and initialized purely through Customize.

The old `smex-initialize` function has been removed, as its functionality is handled entirely within `smex-mode`.

This resolves issue #11
