### PR TITLE
Allow smex to work with command-frequency

### DIFF
--- a/smex.el
+++ b/smex.el
@@ -109,6 +109,9 @@ Set this to nil to disable fuzzy matching."
       (unwind-protect
           (progn (setq prefix-arg current-prefix-arg)
                  (setq this-command chosen-item)
+                 ;; Normally setting real-this-command is very bad, but in this case we really want it.
+                 ;; See the comment in execute-extended-command (which does the same thing).
+                 (setq real-this-command chosen-item)
                  (command-execute chosen-item 'record))
         (smex-rank chosen-item)
         (smex-show-key-advice chosen-item)


### PR DESCRIPTION
Right now when I use smex with command-frequency it ends up keeping track of how many times I call smex instead of the commands that I execute.  Command-frequency uses real-last-command, and works with `execute-extended-command'.  The comment in`execute-extended-command' mentions that `real-this-command' should be set so that`repeat' will work.
