### PR TITLE
Add emacs partial completions 

### DIFF
--- a/smex.el
+++ b/smex.el
@@ -131,7 +131,8 @@ Set this to nil to disable fuzzy matching."
         (ido-setup-hook (cons 'smex-prepare-ido-bindings ido-setup-hook))
         (ido-enable-prefix nil)
         (ido-enable-flex-matching smex-flex-matching)
-        (ido-max-prospects 10))
+        (ido-max-prospects 10)
+        (minibuffer-completion-table choices))
     (ido-completing-read (smex-prompt-with-prefix-arg) choices nil nil
                          initial-input nil (car choices))))
 
@@ -149,6 +150,8 @@ Set this to nil to disable fuzzy matching."
      smex-prompt-string)))
 
 (defun smex-prepare-ido-bindings ()
+  (define-key ido-completion-map "\t"   'minibuffer-complete)
+  (define-key ido-completion-map "\M-\t"   'minibuffer-complete)
   (define-key ido-completion-map (kbd "C-h f") 'smex-describe-function)
   (define-key ido-completion-map (kbd "C-h w") 'smex-where-is)
   (define-key ido-completion-map (kbd "M-.") 'smex-find-function)


### PR DESCRIPTION
   Emacs has a nice partial completion mechanism in minibuffer. It also works  with smex.

```
Also bind TAB and M-TAB to minibuffer-complete. TAB is standard for
minibufer, M-TAB is standard for all other emacs buffers. Better be
consistent.
```

Just for completeness: partial completion is when sw-t-b is completed to switch-to-buffer. 
