### PR TITLE
Add smex- prefix to save-file-not-empty-p

### DIFF
--- a/smex.el
+++ b/smex.el
@@ -259,7 +259,7 @@ Set this to nil to disable fuzzy matching."
                      (if (not (boundp 'smex-data))    (setq smex-data))))))
       (setq smex-history nil smex-data nil))))
 
-(defsubst save-file-not-empty-p ()
+(defsubst smex-save-file-not-empty-p ()
   (string-match-p "\[^[:space:]\]" (buffer-string)))
 
 (defun smex-save-history ()


### PR DESCRIPTION
This should have changed as part of 45fb8635d15c8994c0a0e14bdedfd69f02e4339f, but the function was not actually renamed. This is also referenced in #29. Change allows you to use `(setq smex-save-file null-device)`, for example.
