### PR TITLE
Acronyms and hiding

### DIFF
--- a/smex.el
+++ b/smex.el
@@ -55,8 +55,8 @@ one of these regexes will be hide."
   :initialize 'custom-initialize-default
   :set (lambda (symbol value)
          (set-default symbol value)
-         (smex-update)))
-  :group 'smex
+         (smex-update))
+  :group 'smex)
 
 (defcustom smex-save-file (locate-user-emacs-file "smex-items" ".smex-items")
   "File in which the smex state is saved between Emacs sessions.

--- a/smex.el
+++ b/smex.el
@@ -461,25 +461,18 @@ sorted by frequency of use."
     (set-buffer-modified-p nil)
     (goto-char (point-min))))
 
-;;; Filters ido-matches setting acronynm matches in front of the results
 (defadvice ido-set-matches-1 (after ido-smex-acronym-matches activate)
+  "Filters ido-matches by setting acronynms in front of the ad-return-value."
   (if (and smex-acronyms (> (length ido-text) 1))
       (let ((regex (concat "^" (mapconcat 'char-to-string ido-text "[^-]*-")))
-            (acronym-matches (list))
-            (remove-regexes '("-menu-")))
+            (acronym-matches (list)))
+
         ;; Creating the list of the results to be set as first
         (dolist (item items)
           (if (string-match (concat regex "[^-]*$") item) ;; strict match
               (add-to-list 'acronym-matches item)
             (if (string-match regex item) ;; appending relaxed match
                 (add-to-list 'acronym-matches item t))))
-
-        ;; Filtering ad-return-value
-        (dolist (to_remove remove-regexes)
-          (setq ad-return-value
-                (delete-if (lambda (item)
-                             (string-match to_remove item))
-                           ad-return-value)))
 
         ;; Creating resulting list
         (setq ad-return-value

--- a/smex.el
+++ b/smex.el
@@ -504,7 +504,7 @@ sorted by frequency of use."
 
 (defadvice ido-set-matches-1 (after ido-smex-acronym-matches activate)
   "Filters ido-matches by setting acronynms in front of the ad-return-value."
-  (if (and smex-acronyms (> (length ido-text) 1))
+  (if (and smex-acronyms (smex-already-running) (> (length ido-text) 1))
       (let ((regex (concat "^" (mapconcat 'char-to-string ido-text "[^-]*-")))
             (acronym-matches (list)))
 

--- a/smex.el
+++ b/smex.el
@@ -486,8 +486,7 @@ sorted by frequency of use."
               (append acronym-matches
                       ad-return-value))
 
-        (delete-dups ad-return-value)
-        (reverse ad-return-value))))
+        (delete-dups ad-return-value))))
 
 (provide 'smex)
 ;;; smex.el ends here

--- a/smex.el
+++ b/smex.el
@@ -48,6 +48,16 @@ Turn it off for minor speed improvements on older systems."
   :type 'boolean
   :group 'smex)
 
+(defcustom smex-filter-alist nil
+  "List used by `Smex' to hide command names. Every command name that matches
+one of these regexes will be hide."
+  :type '(repeat regexp)
+  :initialize 'custom-initialize-default
+  :set (lambda (symbol value)
+         (set-default symbol value)
+         (smex-update)))
+  :group 'smex
+
 (defcustom smex-save-file (locate-user-emacs-file "smex-items" ".smex-items")
   "File in which the smex state is saved between Emacs sessions.
 Variables stored are: `smex-data', `smex-history'.
@@ -187,7 +197,12 @@ Set this to nil to disable fuzzy matching."
 
   (setq smex-cache (sort smex-cache 'smex-sorting-rules))
   (smex-restore-history)
-  (setq smex-ido-cache (smex-convert-for-ido smex-cache)))
+  (setq smex-ido-cache (smex-filter-commands
+                        (smex-convert-for-ido smex-cache))))
+
+(defun smex-filter-commands (commands)
+  (dolist (filter smex-filter-alist commands)
+    (cl-delete-if (lambda (item) (string-match filter item)) commands)))
 
 (defun smex-convert-for-ido (command-items)
   (mapcar (lambda (command-item) (symbol-name (car command-item))) command-items))

--- a/smex.el
+++ b/smex.el
@@ -54,8 +54,9 @@ one of these regexes will be hide."
   :type '(repeat regexp)
   :initialize 'custom-initialize-default
   :set (lambda (symbol value)
-         (set-default symbol value)
-         (smex-update))
+         (when (fboundp 'smex-cache)
+           (set-default symbol value)
+           (smex-update)))
   :group 'smex)
 
 (defcustom smex-save-file (locate-user-emacs-file "smex-items" ".smex-items")

--- a/smex.el
+++ b/smex.el
@@ -510,10 +510,12 @@ sorted by frequency of use."
 
         ;; Creating the list of the results to be set as first
         (dolist (item items)
-          (if (string-match (concat regex "[^-]*$") item) ;; strict match
+          (if (string-match ido-text item) ;; exact match
               (add-to-list 'acronym-matches item)
-            (if (string-match regex item) ;; appending relaxed match
-                (add-to-list 'acronym-matches item t))))
+            (if (string-match (concat regex "[^-]*$") item) ;; strict match
+                (add-to-list 'acronym-matches item)
+              (if (string-match regex item) ;; relaxed match
+                  (add-to-list 'acronym-matches item t)))))
 
         ;; Creating resulting list
         (setq ad-return-value

--- a/smex.el
+++ b/smex.el
@@ -519,9 +519,7 @@ sorted by frequency of use."
 
         ;; Creating resulting list
         (setq ad-return-value
-              (append acronym-matches
-                      ad-return-value))
+              (delete-dups (append acronym-matches ad-return-value))))))
 
-        (delete-dups ad-return-value))))
 (provide 'smex)
 ;;; smex.el ends here


### PR DESCRIPTION
When the custom variable `smex-acronyms` is non-nil, the user can use acronyms instead of the whole command names.

E.g.: `ff` instead of `find-file` or `ffow` instead of `find-file-other-window`

Custom variable `smex-filter-alist` is a list of regexes that we can use for hiding command.

