### PR TITLE
Change default save file location

### DIFF
--- a/smex.el
+++ b/smex.el
@@ -41,7 +41,10 @@ Turn it off for minor speed improvements on older systems."
   :type 'boolean
   :group 'smex)
 
-(defcustom smex-save-file "~/.smex-items"
+(defcustom smex-save-file
+  (if (file-directory-p user-emacs-directory)
+      (expand-file-name ".smex-items" user-emacs-directory)
+    "~/.smex-items")
   "File in which the smex state is saved between Emacs sessions.
 Variables stored are: `smex-data', `smex-history'.
 Must be set before initializing Smex."


### PR DESCRIPTION
Emacs 24.4 now defaults to storing user data files in `~/.emacs.d/` if present. This change makes `smex` do the same.

If you'd prefer, I can submit a slightly bigger change which prefers `~/.smex-items` if already present, to avoid any confusion for existing users.
