### PR TITLE
Fix the default for smex-save-file given in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -76,8 +76,8 @@ no key bindings.
 
 ### Persistence
 Smex keeps a file to save its state betweens Emacs sessions. The
-default path is "~/.smex-items"; you can change it by setting the
-variable `smex-save-file`.
+default path is `~/.emacs.d/smex-items`; you can change it by setting
+the variable `smex-save-file`.
 
 ### History
 Set `smex-history-length` to change the number of recent commands that


### PR DESCRIPTION
When reading the REAME, I was mildly concerned that smex was putting things in my home directory before I looked at the actual value of `smex-save-file`. This pull request substitutes the correct default value of `smex-save-file` in the README.

(See the extended commit message.)
