### PR TITLE
Require a match when completing commands

### DIFF
--- a/Cask
+++ b/Cask
@@ -2,3 +2,5 @@
 (source melpa)
 
 (package-file "smex.el")
+
+(depends-on "ido-completing-read+")

--- a/smex.el
+++ b/smex.el
@@ -7,6 +7,7 @@
 ;; Package-Requires: ((emacs "24"))
 ;; Version: 3.0
 ;; Keywords: convenience, usability
+;; Package-Requires: ((ido-completing-read+ "0"))
 
 ;; This file is not part of GNU Emacs.
 
@@ -28,6 +29,7 @@
 ;;; Code:
 
 (require 'ido)
+(require 'ido-completing-read+)
 
 (defgroup smex nil
   "M-x interface with Ido-style fuzzy matching and ranking heuristics."
@@ -135,8 +137,8 @@ Set this to nil to disable fuzzy matching."
         (ido-enable-flex-matching smex-flex-matching)
         (ido-max-prospects 10)
         (minibuffer-completion-table choices))
-    (ido-completing-read (smex-prompt-with-prefix-arg) choices nil nil
-                         initial-input 'extended-command-history (car choices))))
+    (ido-completing-read+ (smex-prompt-with-prefix-arg) choices nil t
+                          initial-input 'extended-command-history (car choices))))
 
 (defun smex-prompt-with-prefix-arg ()
   (if (not current-prefix-arg)

--- a/smex.el
+++ b/smex.el
@@ -4,7 +4,7 @@
 ;;
 ;; Author: Cornelius Mika <cornelius.mika@gmail.com> and contributors
 ;; URL: http://github.com/nonsequitur/smex/
-;; Package-Requires: ((emacs "24"))
+;; Package-Requires: ((emacs "24") (ido-completing-read+ "3.0"))
 ;; Version: 3.0
 ;; Keywords: convenience, usability
 ;; Package-Requires: ((ido-completing-read+ "0"))

--- a/smex.el
+++ b/smex.el
@@ -138,7 +138,7 @@ Set this to nil to disable fuzzy matching."
         (ido-max-prospects 10)
         (minibuffer-completion-table choices))
     (ido-completing-read+ (smex-prompt-with-prefix-arg) choices nil t
-                          initial-input 'extended-command-history (car choices))))
+                          initial-input 'extended-command-history)))
 
 (defun smex-prompt-with-prefix-arg ()
   (if (not current-prefix-arg)


### PR DESCRIPTION
This sets the `require-match` argument to `t` when calling `ido-completing-read`, and it also switches to using [ido-completing-read+][1], since standard ido doesn't handle `require-match` being non-nil.

A second commit also removes an obsolete fix for a problem that should no longer exist.

[1]: https://github.com/DarwinAwardWinner/ido-ubiquitous#ido-completing-read